### PR TITLE
✨ npm-publish

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,10 +8,6 @@ end_of_line = lf
 max_line_length = 80
 trim_trailing_whitespace = true
 
-# Custom
-# Use tabs: https://alexandersandberg.com/articles/default-to-tabs-instead-of-spaces-for-an-accessible-first-environment/
-indent_style = tab
-
 [*.{yaml,yml}]
 # YAML disallows tabs: https://yaml.org/spec/
 indent_size = 2

--- a/.github/workflows/npm-ci-build~v1.yaml
+++ b/.github/workflows/npm-ci-build~v1.yaml
@@ -99,6 +99,7 @@ jobs:
           compression-level: 0 # already compressed as gzipped tarball
 
       - name: Generate artifact attestation
+        if: github.ref == 'refs/heads/main'
         uses: actions/attest-build-provenance@v1
         with:
           subject-path: ${{ steps.Pack.outputs.npmPackFilename }}

--- a/.github/workflows/npm-ci-build~v1.yaml
+++ b/.github/workflows/npm-ci-build~v1.yaml
@@ -28,11 +28,6 @@ jobs:
       npmPackFilename: ${{ steps.Pack.outputs.npmPackFilename }}
       semVer: ${{ steps.GitVersion.outputs.semVer }}
 
-    permissions:
-      attestations: write
-      contents: read
-      id-token: write
-
     runs-on: ubuntu-latest
 
     steps:
@@ -97,9 +92,3 @@ jobs:
           path: ${{ steps.Pack.outputs.npmPackFilename }}
           if-no-files-found: error
           compression-level: 0 # already compressed as gzipped tarball
-
-      - name: Generate artifact attestation
-        if: github.ref == 'refs/heads/main'
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-path: ${{ steps.Pack.outputs.npmPackFilename }}

--- a/.github/workflows/npm-ci-build~v1.yaml
+++ b/.github/workflows/npm-ci-build~v1.yaml
@@ -12,6 +12,9 @@ on:
         required: false
         default: library
     outputs:
+      npmPackFilename:
+        description: The name of the packed npm package (the gzipped tarball).
+        value: ${{ jobs.NpmCiBuild.outputs.npmPackFilename }}
       semVer:
         description: The SemVer version number of this build (automated with GitVersion).
         value: ${{ jobs.NpmCiBuild.outputs.semVer }}
@@ -20,9 +23,18 @@ jobs:
   NpmCiBuild:
     # Workflow names appear as `origin name / workflow name`, so use `npm` for something like `CI Build / npm`
     name: npm
-    runs-on: ubuntu-latest
+
     outputs:
+      npmPackFilename: ${{ steps.Pack.outputs.npmPackFilename }}
       semVer: ${{ steps.GitVersion.outputs.semVer }}
+
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+
+    runs-on: ubuntu-latest
+
     steps:
       - name: Validate inputs
         uses: actions/github-script@v7
@@ -60,6 +72,7 @@ jobs:
         with:
           cache: npm
           node-version-file: .node-version
+          registry-url: https://registry.npmjs.org
 
       - name: Install
         run: npm ci --strict-peer-deps
@@ -68,4 +81,24 @@ jobs:
         run: npm run ci-build
 
       # TODO: Test artifacts, using inputs.hasTests
-      # TODO: Publish pack artifact, using inputs.projectType
+
+      - name: Pack
+        id: Pack
+        run: |
+          npm pack
+
+          $npmPackFilename = $(jq '.name + "-" + .version + ".tgz"' < package.json)
+          echo "npmPackFilename=$npmPackFilename" >> $GITHUB_OUTPUT
+
+      - name: Upload packed artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.Pack.outputs.npmPackFilename }}
+          path: ${{ steps.Pack.outputs.npmPackFilename }}
+          if-no-files-found: error
+          compression-level: 0 # already compressed as gzipped tarball
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: ${{ steps.Pack.outputs.npmPackFilename }}

--- a/.github/workflows/npm-ci-build~v1.yaml
+++ b/.github/workflows/npm-ci-build~v1.yaml
@@ -87,7 +87,7 @@ jobs:
         run: |
           npm pack
 
-          $npmPackFilename = $(jq '.name + "-" + .version + ".tgz"' < package.json)
+          $npmPackFilename=$(jq '.name + "-" + .version + ".tgz"' < package.json)
           echo "npmPackFilename=$npmPackFilename" >> $GITHUB_OUTPUT
 
       - name: Upload packed artifact

--- a/.github/workflows/npm-ci-build~v1.yaml
+++ b/.github/workflows/npm-ci-build~v1.yaml
@@ -87,7 +87,7 @@ jobs:
         run: |
           npm pack
 
-          $npmPackFilename=$(jq '.name + "-" + .version + ".tgz"' < package.json)
+          npmPackFilename=$(jq '.name + "-" + .version + ".tgz"' < package.json)
           echo "npmPackFilename=$npmPackFilename" >> $GITHUB_OUTPUT
 
       - name: Upload packed artifact

--- a/.github/workflows/npm-ci-build~v1.yaml
+++ b/.github/workflows/npm-ci-build~v1.yaml
@@ -87,7 +87,7 @@ jobs:
         run: |
           npm pack
 
-          npmPackFilename=$(jq '.name + "-" + .version + ".tgz"' < package.json)
+          npmPackFilename=$(jq '.name + "-" + .version + ".tgz"' -r < package.json)
           echo "npmPackFilename=$npmPackFilename" >> $GITHUB_OUTPUT
 
       - name: Upload packed artifact

--- a/.github/workflows/npm-publish~v1.yaml
+++ b/.github/workflows/npm-publish~v1.yaml
@@ -9,6 +9,10 @@ on:
         description: The SemVer version number of this build (automated with GitVersion).
         type: string
         required: true
+    secrets:
+      NPM_TOKEN:
+        description: Credentials token for publishing to the npm registry.
+        required: true
 
 jobs:
   NpmPublish:

--- a/.github/workflows/npm-publish~v1.yaml
+++ b/.github/workflows/npm-publish~v1.yaml
@@ -1,0 +1,47 @@
+on:
+  workflow_call:
+    inputs:
+      npmPackFilename:
+        description: The name of the packed npm package (the gzipped tarball).
+        type: string
+        required: true
+      semVer:
+        description: The SemVer version number of this build (automated with GitVersion).
+        type: string
+        required: true
+
+jobs:
+  NpmPublish:
+    # Workflow names appear as `origin name / workflow name`, so use `npm` for something like `Publish / npm`
+    name: npm
+    # FIXME: Uncomment when done testing
+    # if: ${{ github.ref == 'refs/heads/main' }}
+
+    permissions:
+      contents: write
+      id-token: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.npmPackFilename }}
+
+      - uses: actions/setup-node@v4
+        with:
+          cache: npm
+          node-version-file: .node-version
+          registry-url: https://registry.npmjs.org
+
+      - name: Publish
+        run: npm publish ${{ inputs.npmPackFilename }} --provenance --access public --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Tag
+        # FIXME: Remove `if: false` when done testing
+        if: false
+        run: |
+          git tag v${{ inputs.semVer }}
+          git push origin tag v${{ inputs.semVer }}

--- a/.github/workflows/npm-publish~v1.yaml
+++ b/.github/workflows/npm-publish~v1.yaml
@@ -37,13 +37,11 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Publish
-        run: npm publish ${{ inputs.npmPackFilename }} --provenance --access public --dry-run
+        run: npm publish ${{ inputs.npmPackFilename }} --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Tag
-        # FIXME: Remove `if: false` when done testing
-        if: false
         run: |
           git tag v${{ inputs.semVer }}
           git push origin tag v${{ inputs.semVer }}

--- a/.github/workflows/npm-publish~v1.yaml
+++ b/.github/workflows/npm-publish~v1.yaml
@@ -15,7 +15,7 @@ jobs:
     # Workflow names appear as `origin name / workflow name`, so use `npm` for something like `Publish / npm`
     name: npm
     # FIXME: Uncomment when done testing
-    # if: ${{ github.ref == 'refs/heads/main' }}
+    # if: github.ref == 'refs/heads/main'
 
     permissions:
       contents: write
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           cache: npm
-          node-version-file: .node-version
+          node-version: 22
           registry-url: https://registry.npmjs.org
 
       - name: Publish

--- a/.github/workflows/npm-publish~v1.yaml
+++ b/.github/workflows/npm-publish~v1.yaml
@@ -30,7 +30,6 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          cache: npm
           node-version: 22
           registry-url: https://registry.npmjs.org
 

--- a/.github/workflows/npm-publish~v1.yaml
+++ b/.github/workflows/npm-publish~v1.yaml
@@ -18,8 +18,7 @@ jobs:
   NpmPublish:
     # Workflow names appear as `origin name / workflow name`, so use `npm` for something like `Publish / npm`
     name: npm
-    # FIXME: Uncomment when done testing
-    # if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
 
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ Job that executes `ci-build` logic for npm packages.
 
 ```yaml
 jobs:
-  ci-build:
-    uses: connorjs/github-workflows/.github/workflows/npm-ci-build~v1.yaml
+  CiBuild:
+    name: CI Build
+    uses: connorjs/github-workflows/.github/workflows/npm-ci-build~v1.yaml@main
 ```
 
 `v1` runs `ci-build` directly and assumes that the underlying package orchestrates the full build correctly.
@@ -57,9 +58,10 @@ jobs:
 
 #### Outputs
 
-|   Name   |                             Description                              |
-|:--------:|:--------------------------------------------------------------------:|
-| `semVer` | The SemVer version number of this build (automated with GitVersion). |
+|       Name        |                             Description                              |
+|:-----------------:|:--------------------------------------------------------------------:|
+| `npmPackFilename` |      The name of the packed npm package (the gzipped tarball).       |
+|     `semVer`      | The SemVer version number of this build (automated with GitVersion). |
 
 #### Assumptions
 
@@ -80,6 +82,39 @@ Use `+semver:(major|minor)` in commit messages appropriately.
 (Patch happens automatically.)
 
 </details>
+
+### npm-publish
+
+Job that publishes an npm package to the npm registry.
+
+```yaml
+jobs:
+  Publish:
+    name: Publish
+    uses: connorjs/github-workflows/.github/workflows/npm-publish~v1.yaml@main
+```
+
+`v1` publishes a pre-packed artifact (assumed to originate from `npm-ci-build`) and pushes a git tag.
+
+#### Inputs
+
+|       Name        |                             Description                              |
+|:-----------------:|:--------------------------------------------------------------------:|
+| `npmPackFilename` |      The name of the packed npm package (the gzipped tarball).       |
+|     `semVer`      | The SemVer version number of this build (automated with GitVersion). |
+
+These inputs match the outputs from [npm-ci-build](#npm-ci-build).
+
+#### Outputs
+
+None.
+
+#### Assumptions
+
+The job makes the following assumptions about the repository.
+
+- Uses a `.node-version` file in the root of the repository to set the Node.js version.
+- Uses npm (not yarn or pnpm).
 
 ## Goal: Universal targets
 

--- a/README.md
+++ b/README.md
@@ -43,11 +43,6 @@ jobs:
     name: CI Build
 
     uses: connorjs/github-workflows/.github/workflows/npm-ci-build~v1.yaml@main
-
-    permissions:
-      attestations: write
-      contents: read
-      id-token: write
 ```
 
 `v1` runs `ci-build` directly and assumes that the underlying package orchestrates the full build correctly.

--- a/README.md
+++ b/README.md
@@ -129,8 +129,9 @@ None.
 
 The job makes the following assumptions about the repository.
 
-- Uses a `.node-version` file in the root of the repository to set the Node.js version.
 - Uses npm (not yarn or pnpm).
+- Publishes successfully with the latest Node.js version.
+  (This workflow does not use the repository’s `.node-version` because it only runs `npm publish`.)
 
 ## Goal: Universal targets
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Job that executes `ci-build` logic for npm packages.
 jobs:
   CiBuild:
     name: CI Build
-
     uses: connorjs/github-workflows/.github/workflows/npm-ci-build~v1.yaml@main
 ```
 
@@ -97,8 +96,10 @@ jobs:
 
     uses: connorjs/github-workflows/.github/workflows/npm-publish~v1.yaml@main
     with:
-      npmPackFilename: ${{needs.CiBuild.outputs.npmPackFilename}}
-      semVer: ${{needs.CiBuild.outputs.semVer}}
+      npmPackFilename: ${{ needs.CiBuild.outputs.npmPackFilename }}
+      semVer: ${{ needs.CiBuild.outputs.semVer }}
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     permissions:
       contents: write
@@ -114,7 +115,13 @@ jobs:
 | `npmPackFilename` |      The name of the packed npm package (the gzipped tarball).       |
 |     `semVer`      | The SemVer version number of this build (automated with GitVersion). |
 
-These inputs match the outputs from [npm-ci-build](#npm-ci-build).
+These inputs match the outputs from [npm-ci-build](#npm-ci-build).#### Inputs
+
+#### Secrets
+
+|    Name     |                      Description                      |
+|:-----------:|:-----------------------------------------------------:|
+| `NPM_TOKEN` | Credentials token for publishing to the npm registry. |
 
 #### Outputs
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,13 @@ Job that executes `ci-build` logic for npm packages.
 jobs:
   CiBuild:
     name: CI Build
+
     uses: connorjs/github-workflows/.github/workflows/npm-ci-build~v1.yaml@main
+
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
 ```
 
 `v1` runs `ci-build` directly and assumes that the underlying package orchestrates the full build correctly.
@@ -91,7 +97,17 @@ Job that publishes an npm package to the npm registry.
 jobs:
   Publish:
     name: Publish
+    needs:
+      - CiBuild
+
     uses: connorjs/github-workflows/.github/workflows/npm-publish~v1.yaml@main
+    with:
+      npmPackFilename: ${{needs.CiBuild.outputs.npmPackFilename}}
+      semVer: ${{needs.CiBuild.outputs.semVer}}
+
+    permissions:
+      contents: write
+      id-token: write
 ```
 
 `v1` publishes a pre-packed artifact (assumed to originate from `npm-ci-build`) and pushes a git tag.


### PR DESCRIPTION
Creates `npm-publish~v1.yaml` workflow that publishes a package to the
npm registry. Extends `npm-ci-build` to pack the package and publish it
as a workflow artifact (for the other job to download it and publish to
npm).

Removes tabs from .editorconfig because (a) it caused issues with YAML in
markdown and (b) this only has YAML files which disallows tabs.