### PR TITLE
🐛 Fix git tag for npm-publish

### DIFF
--- a/.github/workflows/npm-publish~v1.yaml
+++ b/.github/workflows/npm-publish~v1.yaml
@@ -27,13 +27,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout self
+        uses: actions/checkout@v4
+
       - uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.npmPackFilename }}
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: .node-version
           registry-url: https://registry.npmjs.org
 
       - name: Publish

--- a/README.md
+++ b/README.md
@@ -131,9 +131,8 @@ None.
 
 The job makes the following assumptions about the repository.
 
+- Uses a `.node-version` file in the root of the repository to set the Node.js version.
 - Uses npm (not yarn or pnpm).
-- Publishes successfully with the latest Node.js version.
-  (This workflow does not use the repository’s `.node-version` because it only runs `npm publish`.)
 
 ## Goal: Universal targets
 


### PR DESCRIPTION
Fixes git tag for `npm-publish` workflow. Restores `.node-version` usage.